### PR TITLE
Rate-limit exceptions in Express handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dump.rdb
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -177,3 +177,25 @@ server.get(
   controllerB
 );
 ```
+
+
+## Rate-limiting on exceptions in HTTP handlers
+
+Given an Express handler, return a transformed handler that will rate-limit if the user causes too many exceptions.
+ 
+```js
+var opts = {
+  redis: client,
+  rate: '10/minute',
+  key: ipAndRoute  // as defined above  
+};
+
+var errorMatcher = function(e) { return e instanceOf MyCustomError; };  // if omitted, rate-limits all exceptions
+var errorMessage = "Stop doing that!";  // if omitted, uses generic message
+
+
+server.get(
+    {name: 'routeA', path: '/a'}, 
+    handlerExceptions(opts, myHandler, errorMatcher, errorMessage)
+);
+```

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ server.get(
 Given an Express handler, return a transformed handler that will rate-limit if the user causes too many exceptions.
  
 ```js
+var rateLimiter = require('redis-rate-limiter');
+var handlerExceptions = rateLimiter.handlerExceptions;
+
 var opts = {
   redis: client,
   rate: '10/minute',
@@ -192,7 +195,6 @@ var opts = {
 
 var errorMatcher = function(e) { return e instanceOf MyCustomError; };  // if omitted, rate-limits all exceptions
 var errorMessage = "Stop doing that!";  // if omitted, uses generic message
-
 
 server.get(
     {name: 'routeA', path: '/a'}, 

--- a/lib/handler-exceptions.js
+++ b/lib/handler-exceptions.js
@@ -41,7 +41,7 @@ module.exports = function(opts, handler, errorMatcher, errorMessage) {
         var realKey = 'ratelimit:{' + key + '}';
 
         // Tally an error in redis. This is similar to rate-limiter.js
-        var incrementErrors = function () {
+        var incrementErrors = function (callback) {
             var tempKey = 'ratelimittemp:{' + key + '}';
             opts.redis.multi()
                 .setex(tempKey, opts.window(), 0)
@@ -50,25 +50,24 @@ module.exports = function(opts, handler, errorMatcher, errorMessage) {
                 .ttl(realKey)
                 .exec(function (redisError, results) {
                     if (redisError) {
-                        next(redisError);
+                        console.error("redis error in incr: " + redisError.constructor.name + ": " + redisError.message);
                     } else {
-                        var ttlResult = results[3];
+                        var ttlResult = parseInt(results[3], 10);
                         if (ttlResult === -1) {  // automatically recover from possible race condition
                             opts.redis.expire(realKey, opts.window());
-                        } else {
-                            next(request, response);
                         }
                     }
+                    callback();
                 });
         };
 
-        // Execute the original handler, but if it throws an exception, tally that in Redis
+        // Execute the original handler, but if it throws an exception we want to count, tally that in Redis
         function callHandler() {
             try {
                 handler.call(this, request, response, next);
             } catch (error) {
                 if (errorMatcher(error)) {
-                    incrementErrors();
+                    incrementErrors(function() { next(error); });
                 } else {
                     next(error);
                 }
@@ -78,11 +77,12 @@ module.exports = function(opts, handler, errorMatcher, errorMessage) {
         // If we recently had too many exceptions, respond with a rate limit HTTP error
         opts.redis.get(realKey, function (redisError, results) {
             if (redisError) {
-                next(redisError);
+                console.error("redis error in get: " + redisError.constructor.name + ": " + redisError.message);
+                next();
             } else {
-                var current = results[0];
-                if (current > opts.limit()) {
-                    response.writeHead(429);
+                var current = results == null ? 0 : parseInt(results, 10);
+                if (current >= opts.limit()) {
+                    response.status(429);
                     response.send(errorMessage);
                     response.end();
                 } else {

--- a/lib/handler-exceptions.js
+++ b/lib/handler-exceptions.js
@@ -1,0 +1,96 @@
+var assert  = require('assert');
+var options = require('./options');
+
+/**
+ * Given an Express handler, return a handler that responds with a 429 HTTP Error if they cause too many exceptions.
+ *
+ * This uses the optional errorMatcher function to decide if it should throw an error. If that is not supplied,
+ * it will rate-limit on all exceptions.
+ *
+ * Sample use:
+ *
+ * const redisRateLimiter = require('redis-rate-limiter');
+ *
+ * const opts = {
+ *    redis: redisClient,
+ *    rate: '10/hour',
+ *    key: req => `${req.path}:${req.forwarded_ip}`,
+ * },
+ * const errorMatcher = e => e instanceOf MyCustomError;
+ * const myRateLimitedHandler = redisRateLimiter.handlerExceptions(opts, myHandler, errorMatcher, "Stop Doing That");
+ */
+
+// Transforms a handler into an exception-rate-limited handler
+module.exports = function(opts, handler, errorMatcher, errorMessage) {
+
+    // Make sure all the args are good
+    opts = options.canonical(opts);
+    assert.equal(typeof handler, 'function', 'Invalid handler: ' + handler);
+    if (!errorMatcher) {
+        errorMatcher = function () { return true; } ;
+    } else {
+        assert.equal(typeof errorMatcher, 'function', 'Invalid error matcher: ' + errorMatcher);
+    }
+    if (!errorMessage) {
+        errorMessage = "Too Many Errors";
+    }
+
+    // Return the new handler
+    return function(request, response, next) {
+        var key = opts.key(request);
+        var realKey = 'ratelimit:{' + key + '}';
+
+        // Tally an error in redis. This is similar to rate-limiter.js
+        var incrementErrors = function () {
+            var tempKey = 'ratelimittemp:{' + key + '}';
+            opts.redis.multi()
+                .setex(tempKey, opts.window(), 0)
+                .renamenx(tempKey, realKey)
+                .incr(realKey)
+                .ttl(realKey)
+                .exec(function (redisError, results) {
+                    if (redisError) {
+                        next(redisError);
+                    } else {
+                        var ttlResult = results[3];
+                        if (ttlResult === -1) {  // automatically recover from possible race condition
+                            opts.redis.expire(realKey, opts.window());
+                        } else {
+                            next(request, response);
+                        }
+                    }
+                });
+        };
+
+        // Execute the original handler, but if it throws an exception, tally that in Redis
+        function callHandler() {
+            try {
+                handler.call(this, request, response, next);
+            } catch (error) {
+                if (errorMatcher(error)) {
+                    incrementErrors();
+                } else {
+                    next(error);
+                }
+            }
+        }
+
+        // If we recently had too many exceptions, respond with a rate limit HTTP error
+        opts.redis.get(realKey, function (redisError, results) {
+            if (redisError) {
+                next(redisError);
+            } else {
+                var current = results[0];
+                if (current > opts.limit()) {
+                    response.writeHead(429);
+                    response.send(errorMessage);
+                    response.end();
+                } else {
+                    callHandler();
+                }
+            }
+        });
+
+    }
+};
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 
 exports.create    = require('./rate-limiter');
 exports.middleware = require('./middleware');
+exports.handlerExceptions = require('./handler-exceptions');

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -5,7 +5,7 @@ module.exports = function(opts) {
   return function(req, res, next) {
     limiter(req, function(err, rate) {
       if (err) {
-        console.error(err);
+        console.error(err.constructor.name + ": " + err.message);
         next();
       } else {
         if (rate.current > rate.limit) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -32,7 +32,7 @@
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
     },
     "asynckit": {
@@ -54,15 +54,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       }
     },
     "brace-expansion": {
@@ -71,7 +71,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -99,7 +99,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -201,8 +201,8 @@
       "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
-        "defined": "1.0.0"
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
       }
     },
     "diff": {
@@ -253,36 +253,36 @@
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "extend": {
@@ -298,12 +298,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "form-data": {
@@ -312,9 +312,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "formidable": {
@@ -347,12 +347,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -382,7 +382,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "setprototypeof": {
@@ -405,8 +405,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -475,7 +475,7 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "minimatch": {
@@ -484,7 +484,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -563,7 +563,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "parseurl": {
@@ -596,7 +596,7 @@
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
     },
@@ -630,10 +630,10 @@
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -650,13 +650,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "redis": {
@@ -665,9 +665,9 @@
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "dev": true,
       "requires": {
-        "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.1",
-        "redis-parser": "2.6.0"
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
       }
     },
     "redis-commands": {
@@ -688,11 +688,11 @@
       "integrity": "sha1-dDytyB1xjWVia5pO+c/njPIe80o=",
       "dev": true,
       "requires": {
-        "builtins": "1.0.3",
-        "detective": "4.7.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "rc": "1.2.2"
+        "builtins": "^1.0.3",
+        "detective": "^4.3.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.5.1",
+        "rc": "^1.2.1"
       }
     },
     "safe-buffer": {
@@ -708,18 +708,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       }
     },
     "serve-static": {
@@ -728,9 +728,9 @@
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       }
     },
@@ -746,11 +746,11 @@
       "integrity": "sha512-1m8FHuNTrJ37pXfjfhjmv1/jBw2eYZIWibQ1pH2EGYhn8TcPOSK6zjNbhF20sZ4Gc0XSIlSaSGupnYRKkk1pKQ==",
       "dev": true,
       "requires": {
-        "should-equal": "2.0.0",
-        "should-format": "3.0.3",
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.0.1",
-        "should-util": "1.0.0"
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
       }
     },
     "should-equal": {
@@ -759,7 +759,7 @@
       "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "dev": true,
       "requires": {
-        "should-type": "1.4.0"
+        "should-type": "^1.4.0"
       }
     },
     "should-format": {
@@ -768,8 +768,8 @@
       "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "dev": true,
       "requires": {
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.0.1"
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
       }
     },
     "should-type": {
@@ -784,8 +784,8 @@
       "integrity": "sha1-7+VVPN9oz/ZuXF9RtxLcNRx3vqo=",
       "dev": true,
       "requires": {
-        "should-type": "1.4.0",
-        "should-util": "1.0.0"
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
       }
     },
     "should-util": {
@@ -806,7 +806,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-json-comments": {
@@ -821,16 +821,16 @@
       "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.4.1",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "debug": {
@@ -850,8 +850,8 @@
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
       "dev": true,
       "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.1"
+        "methods": "~1.1.2",
+        "superagent": "^3.0.0"
       }
     },
     "supports-color": {
@@ -860,7 +860,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "type-is": {
@@ -870,7 +870,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "~2.1.15"
       }
     },
     "unpipe": {

--- a/test/handler-exceptions.spec.js
+++ b/test/handler-exceptions.spec.js
@@ -5,8 +5,27 @@ var redis        = require('redis');
 var express      = require('express');
 var supertest    = require('supertest');
 var reset        = require('./reset');
+var handlerExceptions = require('../lib/handler-exceptions');
+var helper       = require('./middleware-helper');
+
+var requests = helper.requests;
+var parallelRequests = helper.parallelRequests;
+var wait = helper.wait;
+var okResponse = helper.okResponse;
+var withStatus = helper.withStatus
+
+
+// we define our own error handler so that Express doesn't print it to stderr
+function errorHandler(err, req, res, next) {
+    res.status(500).send('Error!\n\n' + err.stack)
+}
 
 describe('Handler Exceptions', function() {
+
+    this.slow(5000);
+    this.timeout(5000);
+
+    var client = null;
 
     before(function(done) {
         client = redis.createClient(6379, 'localhost', {enable_offline_queue: false});
@@ -20,6 +39,174 @@ describe('Handler Exceptions', function() {
     after(function() {
         client.quit();
     });
+
+    describe('Counter', function() {
+        var maxFails = 10;
+        var server = null;
+
+        function failableHandler(req, res, next) {
+            if (req.query.fail) {
+                throw new Error("whoops");
+            }
+            okResponse(req, res, next);
+        }
+
+        beforeEach(function (done) {
+            server = express();
+            var opts = {
+                redis: client,
+                rate: maxFails.toString() + '/minute',
+                key: 'ip'
+            };
+            var rateLimitedHandler = handlerExceptions(opts, failableHandler);
+            server.use(rateLimitedHandler);
+            server.use(errorHandler);
+            done();
+        });
+
+        var testSuccessFail = function (okCount, failCount, done) {
+            var expectedFailCount = Math.min(failCount, maxFails);
+            var expectedRateLimitedCount = Math.max(0, (failCount - maxFails));
+
+            var okReqs = requests(server, okCount, '/test');
+            var exceptionReqs = requests(server, failCount, '/test?fail=1');
+            var reqs = okReqs.concat(exceptionReqs);
+
+            // We do these in series to ensure that redis has time to do the incr and fetch,
+            // so we get predictable results.
+            async.series(reqs, function (err, data) {
+                withStatus(data, 200).should.have.length(okCount);
+                withStatus(data, 500).should.have.length(expectedFailCount);
+                withStatus(data, 429).should.have.length(expectedRateLimitedCount);
+                done();
+            });
+        };
+
+        it('if no exceptions, passes', function (done) {
+            var successCount = 20;
+            var failCount = 0;
+
+            testSuccessFail(successCount, failCount, done);
+        });
+
+        it('if exceptions under the limit, passes', function (done) {
+            var successCount = 15;
+            var failCount = 5;
+
+            testSuccessFail(successCount, failCount, done);
+        });
+
+        it('if exceptions over the limit, begins rate limiting', function (done) {
+            var successCount = 5;
+            var failCount = 15;
+
+            testSuccessFail(successCount, failCount, done);
+        });
+
+    });
+
+
+    describe('Error matcher', function() {
+       it('should rate limit only some exceptions', function(done) {
+           var maxFails = 10;
+           var server = express();
+
+           function CustomError(message) {
+               this.message = message;
+           }
+           CustomError.prototype = new Error();
+
+           var opts = {
+               redis: client,
+               rate: maxFails.toString() + '/minute',
+               key: 'ip'
+           };
+
+           var errorMatcher = function (error) {
+               return error instanceof CustomError;
+           };
+
+           function failChoiceHandler(req, res, next) {
+               if (req.query.fail) {
+                   var klass = req.query.fail;
+
+                   if (klass === 'CustomError') {
+                       throw new CustomError("boing");
+                   } else {
+                       throw new Error();
+                   }
+               }
+               okResponse(req, res, next);
+           }
+
+           var rateLimitedHandler = handlerExceptions(opts, failChoiceHandler, errorMatcher);
+           server.use(rateLimitedHandler);
+           server.use(errorHandler);
+
+           var okCount = 5;
+           var unRateLimitedFailCount = 20;
+           var rateLimitedFailCount = 15;
+
+           var okReqs = requests(server, okCount, '/test');
+           var unRateLimitedExceptionReqs = requests(server, unRateLimitedFailCount, '/test?fail=Error');
+           var rateLimitedExceptionReqs = requests(server, rateLimitedFailCount, '/test?fail=CustomError');
+           var reqs = okReqs.concat(unRateLimitedExceptionReqs).concat(rateLimitedExceptionReqs);
+
+           // all of the rate-limited errors should 429 over maxFails
+           var expectedRateLimitedCount = Math.max(0, rateLimitedFailCount - maxFails);
+           // we expect 500 errors for all of the un-rate-limited errors, and the ones that are rate-limited, before
+           // rate-limiting kicks in.
+           var expectedFailCount = unRateLimitedFailCount +
+               Math.max(0, rateLimitedFailCount - expectedRateLimitedCount);
+
+           // We do these in series to ensure that redis has time to do the incr and fetch,
+           // so we get predictable results.
+           async.series(reqs, function (err, data) {
+               withStatus(data, 200).should.have.length(okCount);
+               withStatus(data, 500).should.have.length(expectedFailCount);
+               withStatus(data, 429).should.have.length(expectedRateLimitedCount);
+               done();
+           });
+
+
+       });
+
+    });
+
+
+    describe('Error message', function() {
+        it('Should show a custom error message', function(done) {
+            var maxFails = 1;
+            var server = express();
+
+            var opts = {
+                redis: client,
+                rate: maxFails.toString() + '/minute',
+                key: 'ip'
+            };
+
+            function alwaysFailHandler(req, res, next) {
+                throw new Error();
+            }
+
+            var errorMessage = "Oh noes";
+            var rateLimitedHandler = handlerExceptions(opts, alwaysFailHandler, null, errorMessage);
+            server.use(rateLimitedHandler);
+            server.use(errorHandler);
+
+            var reqs = requests(server, 2, '/test');
+
+            async.series(reqs, function (err, data) {
+                data.should.have.length(2);
+                withStatus(data, 500).should.have.length(1);
+                var rateLimitedResponses = withStatus(data, 429);
+                rateLimitedResponses.should.have.length(1);
+                rateLimitedResponses[0].text.should.eql(errorMessage);
+                done();
+            });
+
+        })
+    })
 
 
 });

--- a/test/handler-exceptions.spec.js
+++ b/test/handler-exceptions.spec.js
@@ -1,0 +1,25 @@
+var _            = require('lodash');
+var async        = require('async');
+var should       = require('should');
+var redis        = require('redis');
+var express      = require('express');
+var supertest    = require('supertest');
+var reset        = require('./reset');
+
+describe('Handler Exceptions', function() {
+
+    before(function(done) {
+        client = redis.createClient(6379, 'localhost', {enable_offline_queue: false});
+        client.on('ready', done);
+    });
+
+    beforeEach(function(done) {
+        reset.allkeys(client, done);
+    });
+
+    after(function() {
+        client.quit();
+    });
+
+
+});

--- a/test/middleware-helper.js
+++ b/test/middleware-helper.js
@@ -1,0 +1,49 @@
+var _            = require('lodash');
+var async        = require('async');
+var supertest    = require('supertest');
+
+
+var requests = function(server, count, url) {
+    return _.times(count, function() {
+        return function(next) {
+            supertest(server).get(url).end(next);
+        };
+    });
+};
+
+var parallelRequests = function(server, count, url) {
+    return function(next) {
+        async.parallel(requests(server, count, url), next);
+    };
+};
+
+var wait = function(millis) {
+    return function(next) {
+        setTimeout(next, millis);
+    };
+};
+
+var okResponse = function(req, res, next) {
+    res.writeHead(200);
+    res.end('ok');
+};
+
+var withStatus = function(data, code) {
+    var pretty = data.map(function(d) {
+        return {
+            url: d.req.path,
+            statusCode: d.res.statusCode,
+            body: d.res.body,
+            text: d.res.text
+        }
+    });
+    return _.filter(pretty, {statusCode: code});
+};
+
+module.exports = {
+    requests: requests,
+    parallelRequests: parallelRequests,
+    wait: wait,
+    okResponse: okResponse,
+    withStatus: withStatus
+};

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -3,9 +3,16 @@ var async        = require('async');
 var should       = require('should');
 var redis        = require('redis');
 var express      = require('express');
-var supertest    = require('supertest');
 var reset        = require('./reset');
 var middleware   = require('../lib/middleware');
+var helper       = require('./middleware-helper');
+
+var requests = helper.requests;
+var parallelRequests = helper.parallelRequests;
+var wait = helper.wait;
+var okResponse = helper.okResponse;
+var withStatus = helper.withStatus;
+
 
 describe('Middleware', function() {
 
@@ -113,39 +120,3 @@ describe('Middleware', function() {
   });
 
 });
-
-function requests(server, count, url) {
-  return _.times(count, function() {
-    return function(next) {
-      supertest(server).get(url).end(next);
-    };
-  });
-}
-
-function parallelRequests(server, count, url) {
-  return function(next) {
-    async.parallel(requests(server, count, url), next);
-  };
-}
-
-function wait(millis) {
-  return function(next) {
-    setTimeout(next, 1100);
-  };
-}
-
-function okResponse(req, res, next) {
-  res.writeHead(200);
-  res.end('ok');
-}
-
-function withStatus(data, code) {
-  var pretty = data.map(function(d) {
-    return {
-      url: d.req.path,
-      statusCode: d.res.statusCode,
-      body: d.res.body
-    }
-  });
-  return _.filter(pretty, {statusCode: code});
-}


### PR DESCRIPTION
A possible way to quickly rate-limit users who perform, for instance, dictionary attacks on another user's account

See docs